### PR TITLE
DateTimeOffset should preserve offset

### DIFF
--- a/src/Z.Core/System.DateTimeOffset/DateTimeOffset.SetTime.cs
+++ b/src/Z.Core/System.DateTimeOffset/DateTimeOffset.SetTime.cs
@@ -55,6 +55,6 @@ public static partial class Extensions
     /// <returns>A DateTimeOffset.</returns>
     public static DateTimeOffset SetTime(this DateTimeOffset current, int hour, int minute, int second, int millisecond)
     {
-        return new DateTime(current.Year, current.Month, current.Day, hour, minute, second, millisecond);
+        return new DateTimeOffset(current.Year, current.Month, current.Day, hour, minute, second, millisecond, current.Offset);
     }
 }

--- a/test/Z.Core.Test/System.DateTimeOffset/DateTimeOffset.SetTime.cs
+++ b/test/Z.Core.Test/System.DateTimeOffset/DateTimeOffset.SetTime.cs
@@ -16,13 +16,15 @@ namespace Z.Core.Test
         public void SetTime()
         {
             // Type
-            DateTimeOffset @thisToday = DateTimeOffset.Now;
+            DateTimeOffset @thisToday = DateTimeOffset.UtcNow;
 
             // Exemples
             DateTimeOffset result = @thisToday.SetTime(15); // Set hours to 15
 
             // Unit Test
             Assert.AreEqual(15, result.Hour);
+
+            Assert.AreEqual(thisToday.Offset, result.Offset);
         }
     }
 }


### PR DESCRIPTION
Currently the `DateTimeOffset` extension method has the unexpected behavior of changing the offset to match that of the current system timezone and does not just set the time as suggested by the name.

This change copies the offset to the new `DateTimeOffset`