### PR TITLE
IsValidEmail() Improved Regex Pattern

### DIFF
--- a/src/Z.Core/System.String/zzzRegexPattern/String.IsValidEmail.cs
+++ b/src/Z.Core/System.String/zzzRegexPattern/String.IsValidEmail.cs
@@ -15,6 +15,6 @@ public static partial class Extensions
     /// <returns>true if valid email, false if not.</returns>
     public static bool IsValidEmail(this string obj)
     {
-        return Regex.IsMatch(obj, @"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z0-9]{1,30})(\]?)$");
+        return Regex.IsMatch(obj, @"^\w+([-+.']\w+)*@(\[*\w+)([-.]\w+)*\.\w+([-.]\w+\])*$");
     }
 }

--- a/test/Z.Core.Test/System.String/String.IsValidEmail.cs
+++ b/test/Z.Core.Test/System.String/String.IsValidEmail.cs
@@ -4,7 +4,7 @@
 // License (MIT): https://github.com/zzzprojects/Z.ExtensionMethods/blob/master/LICENSE
 // More projects: https://zzzprojects.com/
 // Copyright © ZZZ Projects Inc. All rights reserved.
-using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Z.Core.Test
@@ -15,26 +15,68 @@ namespace Z.Core.Test
         [TestMethod]
         public void IsValidEmail()
         {
+            // Valid Emails
             {
-                // Type
-                string @this = "test@hotmail.com";
+                // Arrange
+                var validEmails = new[]
+                {
+                    "email@example.com",
+                    "firstname.lastname@example.com",
+                    "email@subdomain.example.com",
+                    "firstname+lastname@example.com",
+                    "email@123.123.123.123",
+                    "email@[123.123.123.123]",
+                    "1234567890@example.com",
+                    "email@example-one.com",
+                    "_______@example.com",
+                    "email@example.name",
+                    "email@example.museum",
+                    "email@example.co.jp",
+                    "firstname-lastname@example.com"
+                };
 
-                // Exemples
-                var result = @this.IsValidEmail(); // return true;
+                // Act
+                foreach (var validEmail in validEmails)
+                {
+                    // Act
+                    var result = validEmail.IsValidEmail();
 
-                // Unit Test
-                Assert.IsTrue(result);
+                    // Assert
+                    Assert.IsTrue(result);
+                }
             }
 
+            // Invalid Emails
             {
-                // Type
-                string @this = "mike@GOTBLOG.ONLINE";
+                // Arrange
+                var invalidEmails = new[]
+                {
+                    "plainaddress",
+                    "#@%^%#$@#$@#.com",
+                    "@example.com",
+                    "Joe Smith <email@example.com>",
+                    "email.example.com",
+                    "email@example@example.com",
+                    ".email@example.com",
+                    "email.@example.com",
+                    "email..email@example.com",
+                    "email@example.com (Joe Smith)",
+                    "email@example",
+                    "email@-example.com",
+                    //"email@example.web", // Should not be valid, not a top level domain, how should we handle this outside regex? Lookup dictionary of all valid top level domains?
+                    "email@example..com",
+                    "Abc..123@example.com"
+                };
 
-                // Exemples
-                var result = @this.IsValidEmail(); // return true;
+                // Act
+                foreach (var validEmail in invalidEmails)
+                {
+                    // Act
+                    var result = validEmail.IsValidEmail();
 
-                // Unit Test
-                Assert.IsTrue(result);
+                    // Assert
+                    Assert.IsFalse(result);
+                }
             }
         }
     }

--- a/test/Z.Core.Test/System.String/String.IsValidEmail.cs
+++ b/test/Z.Core.Test/System.String/String.IsValidEmail.cs
@@ -4,7 +4,6 @@
 // License (MIT): https://github.com/zzzprojects/Z.ExtensionMethods/blob/master/LICENSE
 // More projects: https://zzzprojects.com/
 // Copyright © ZZZ Projects Inc. All rights reserved.
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Z.Core.Test
@@ -36,10 +35,10 @@ namespace Z.Core.Test
                 };
 
                 // Act
-                foreach (var validEmail in validEmails)
+                foreach (var email in validEmails)
                 {
                     // Act
-                    var result = validEmail.IsValidEmail();
+                    var result = email.IsValidEmail();
 
                     // Assert
                     Assert.IsTrue(result);
@@ -63,16 +62,16 @@ namespace Z.Core.Test
                     "email@example.com (Joe Smith)",
                     "email@example",
                     "email@-example.com",
-                    //"email@example.web", // Should not be valid, not a top level domain, how should we handle this outside regex? Lookup dictionary of all valid top level domains?
+                    //"email@example.web", // Should not be valid, not a top level domain, how should we handle this outside regex? Lookup dictionary of all valid top level domains? https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains
                     "email@example..com",
                     "Abc..123@example.com"
                 };
 
                 // Act
-                foreach (var validEmail in invalidEmails)
+                foreach (var email in invalidEmails)
                 {
                     // Act
-                    var result = validEmail.IsValidEmail();
+                    var result = email.IsValidEmail();
 
                     // Assert
                     Assert.IsFalse(result);


### PR DESCRIPTION
Made a slight update to the Regex Pattern to conform more to the rules of [RFC 5322](https://tools.ietf.org/html/rfc5322) which obsoletes [RFC 2822](https://tools.ietf.org/html/rfc2822).

I ended up updating the regex pattern because the built in .NET `MailAddressParser` conforms to RC2822 and did not want to re-implement to conform to RC5322. The supplied regex pattern should match ~99% of valid emails.

More tests have been implemented.

## Old regex pattern:

```
--- Valid Email List ---
True : email@example.com
True : firstname.lastname@example.com
True : email@subdomain.example.com
False : firstname+lastname@example.com
True : email@123.123.123.123
True : email@[123.123.123.123]
True : 1234567890@example.com
True : email@example-one.com
True : _______@example.com
True : email@example.name
True : email@example.museum
True : email@example.co.jp
True : firstname-lastname@example.com

--- Invalid Email List ---
False : plainaddress
False : #@%^%#$@#$@#.com
False : @example.com
False : Joe Smith <email@example.com>
False : email.example.com
False : email@example@example.com
True : .email@example.com
True : email.@example.com
True : email..email@example.com
False : email@example.com (Joe Smith)
False : email@example
True : email@-example.com
False : email@example..com
True : Abc..123@example.com
```

## New regex pattern:

```
--- Valid Email List ---
True : email@example.com
True : firstname.lastname@example.com
True : email@subdomain.example.com
True : firstname+lastname@example.com
True : email@123.123.123.123
True : email@[123.123.123.123]
True : 1234567890@example.com
True : email@example-one.com
True : _______@example.com
True : email@example.name
True : email@example.museum
True : email@example.co.jp
True : firstname-lastname@example.com

--- Invalid Email List ---
False : plainaddress
False : #@%^%#$@#$@#.com
False : @example.com
False : Joe Smith <email@example.com>
False : email.example.com
False : email@example@example.com
False : .email@example.com
False : email.@example.com
False : email..email@example.com
False : email@example.com (Joe Smith)
False : email@example
False : email@-example.com
False : email@example..com
False : Abc..123@example.com
```

For curiosities sake;

## `MailAddress` constructor try/catch:

```
--- Valid Email List ---
True : email@example.com
True : firstname.lastname@example.com
True : email@subdomain.example.com
True : firstname+lastname@example.com
True : email@123.123.123.123
True : email@[123.123.123.123]
True : 1234567890@example.com
True : email@example-one.com
True : _______@example.com
True : email@example.name
True : email@example.museum
True : email@example.co.jp
True : firstname-lastname@example.com

--- Invalid Email List ---
False : plainaddress
False : #@%^%#$@#$@#.com
False : @example.com
True: Joe Smith <email@example.com>
False : email.example.com
False : email@example@example.com
False : .email@example.com
True : email.@example.com
True : email..email@example.com
True : email@example.com (Joe Smith)
True : email@example
True : email@-example.com
True : email@example..com
True : Abc..123@example.com
```

Fixes #27 